### PR TITLE
HMC-720: Rollback WebRTC to version M57 to work around streaming issues in EE network

### DIFF
--- a/RTCPeerConnection.js
+++ b/RTCPeerConnection.js
@@ -12,6 +12,7 @@ import RTCSessionDescription from './RTCSessionDescription';
 import RTCIceCandidate from './RTCIceCandidate';
 import RTCIceCandidateEvent from './RTCIceCandidateEvent';
 import RTCEvent from './RTCEvent';
+import * as RTCUtil from './RTCUtil';
 
 const {WebRTCModule} = NativeModules;
 
@@ -105,6 +106,13 @@ export default class RTCPeerConnection extends EventTarget(PEER_CONNECTION_EVENT
         },
         this._peerConnectionId);
     this._registerEvents();
+    // Allow for legacy callback usage
+    this.createOffer = RTCUtil.promisify(this.createOffer.bind(this), true);
+    this.createAnswer = RTCUtil.promisify(this.createAnswer.bind(this), true);
+    this.setLocalDescription = RTCUtil.promisify(this.setLocalDescription.bind(this));
+    this.setRemoteDescription = RTCUtil.promisify(this.setRemoteDescription.bind(this));
+    this.addIceCandidate = RTCUtil.promisify(this.addIceCandidate.bind(this));
+    this.getStats = RTCUtil.promisify(this.getStats.bind(this));
   }
 
   addStream(stream: MediaStream) {

--- a/RTCUtil.js
+++ b/RTCUtil.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * Merge custom constraints with the default one. The custom one take precedence.
+ *
+ * @param {Object} custom - custom webrtc constraints
+ * @param {Object} def - default webrtc constraints
+ * @return {Object} constraints - merged webrtc constraints
+ */
+export function mergeMediaConstraints(custom, def) {
+  const constraints = (def ? Object.assign({}, def) : {});
+  if (custom) {
+    if (custom.mandatory) {
+      constraints.mandatory = {...constraints.mandatory, ...custom.mandatory};
+    }
+    if (custom.optional && Array.isArray(custom.optional)) {
+      // `optional` is an array, webrtc only finds first and ignore the rest if duplicate.
+      constraints.optional = custom.optional.concat(constraints.optional);
+    }
+    if (custom.facingMode) {
+      constraints.facingMode = custom.facingMode.toString(); // string, 'user' or the default 'environment'
+    }
+  }
+  return constraints;
+}
+
+/**
+ * Returns a Promise and legacy callbacks compatible function
+ * @param {Function} method - The function to make Promise and legacy callbacks compatible
+ * @param {Boolean} [callbackFirst] - Indicate whether or not the success and failure callbacks are the firsts arguments
+ * @returns {Function}
+ */
+export function promisify(method, callbackFirst) {
+  return function(...origArgs) {
+    let onSuccess = origArgs[(callbackFirst ? 0 : origArgs.length - 2)];
+    let onFailure = origArgs[(callbackFirst ? 1 : origArgs.length - 1)];
+    let args = origArgs;
+
+    // --- should promisify functions which has only one success callback.
+
+    if (typeof onSuccess === 'function') {
+      args = args.filter(item => item !== onSuccess);
+    } else {
+      onSuccess = function(res) { return res; };
+    }
+
+    if (typeof onFailure === 'function') {
+      args = args.filter(item => item !== onFailure);
+    } else {
+      onFailure = function(err) { throw err; };
+    }
+
+    // --- always pass resolve/reject as callback
+    return new Promise(function(resolve, reject) {
+      const newArgs = (callbackFirst ? [resolve, reject, ...args] : [...args, resolve, reject]);
+      method(...newArgs);
+    })
+      .then(onSuccess)
+      .catch(onFailure);
+  };
+}

--- a/RTCView.js
+++ b/RTCView.js
@@ -5,7 +5,7 @@ import {
   NativeModules,
   requireNativeComponent,
 } from 'react-native';
-import {PropTypes} from 'react';
+import PropTypes from 'prop-types';
 
 const {WebRTCModule} = NativeModules;
 

--- a/RTCView.js
+++ b/RTCView.js
@@ -65,6 +65,7 @@ const View = requireNativeComponent('RTCVideoView', RTCView, {nativeOnly: {
   accessibilityLiveRegion: true,
   importantForAccessibility: true,
   onLayout: true,
+  onFirstFrame: true,
 }});
 
 export default View;

--- a/android/src/main/java/com/oney/WebRTCModule/IRenderer.java
+++ b/android/src/main/java/com/oney/WebRTCModule/IRenderer.java
@@ -1,0 +1,19 @@
+package com.oney.WebRTCModule;
+
+import android.support.annotation.ColorInt;
+
+import org.webrtc.EglBase;
+import org.webrtc.RendererCommon;
+
+public interface IRenderer extends org.webrtc.VideoRenderer.Callbacks {
+    public abstract void clearImage();
+    public abstract void release();
+    public abstract void setScalingType(RendererCommon.ScalingType scalingType);
+    public abstract void init(EglBase.Context sharedContext, RendererCommon.RendererEvents rendererEvents);
+    public abstract void setBackgroundColor(@ColorInt int color);
+    public abstract void layout(int l, int t, int r, int b);
+    public abstract void requestLayout();
+    public abstract void setMirror(final boolean mirror);
+    public abstract void setZOrderMediaOverlay(boolean isMediaOverlay);
+    public abstract void setZOrderOnTop(boolean onTop);
+}

--- a/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
+++ b/android/src/main/java/com/oney/WebRTCModule/RTCVideoViewManager.java
@@ -1,6 +1,11 @@
 package com.oney.WebRTCModule;
 
+import java.util.Map;
+
+import android.support.annotation.Nullable;
+
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewProps;
@@ -27,6 +32,13 @@ public class RTCVideoViewManager extends SimpleViewManager<WebRTCView> {
     return view;
   }
 
+  @Override
+  public @Nullable Map getExportedCustomDirectEventTypeConstants() {
+    return MapBuilder.of(
+            "onFirstFrame",
+            MapBuilder.of("registrationName", "onFirstFrame")
+    );
+  }
   /**
    * Sets the indicator which determines whether a specific {@link WebRTCView}
    * is to mirror the video specified by {@code streamURL} during its rendering.

--- a/android/src/main/java/com/oney/WebRTCModule/SurfaceViewRenderer.java
+++ b/android/src/main/java/com/oney/WebRTCModule/SurfaceViewRenderer.java
@@ -1,24 +1,38 @@
-package com.oney.WebRTCModule;
+/*
+ *  Copyright 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
 
+// Retrieved from upstream's master on August 26, 2016.
+
+package com.oney.WebRTCModule;
 
 import android.content.Context;
 import android.content.res.Resources.NotFoundException;
 import android.graphics.Point;
+import android.opengl.GLES20;
+import android.os.Handler;
+import android.os.HandlerThread;
 import android.util.AttributeSet;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
+import java.util.concurrent.CountDownLatch;
+
+import javax.microedition.khronos.egl.EGLContext;
+
 import org.webrtc.EglBase;
-import org.webrtc.EglRenderer;
 import org.webrtc.GlRectDrawer;
+import org.webrtc.GlUtil;
 import org.webrtc.Logging;
 import org.webrtc.RendererCommon;
 import org.webrtc.ThreadUtils;
-import org.webrtc.VideoFrame;
 import org.webrtc.VideoRenderer;
-import org.webrtc.VideoSink;
-
-import java.util.concurrent.CountDownLatch;
 
 /**
  * Implements org.webrtc.VideoRenderer.Callbacks by displaying the video stream on a SurfaceView.
@@ -29,362 +43,557 @@ import java.util.concurrent.CountDownLatch;
  * Interaction from the Activity lifecycle in surfaceCreated, surfaceChanged, and surfaceDestroyed.
  * Interaction with the layout framework in onMeasure and onSizeChanged.
  */
-public class SurfaceViewRenderer
-        extends SurfaceView implements SurfaceHolder.Callback, VideoSink, IRenderer {
-    private static final String TAG = "SurfaceViewRenderer";
+public class SurfaceViewRenderer extends SurfaceView
+    implements SurfaceHolder.Callback, VideoRenderer.Callbacks, IRenderer {
+  private static final String TAG = "SurfaceViewRenderer";
 
-    // Cached resource name.
-    private final String resourceName;
-    private final RendererCommon.VideoLayoutMeasure videoLayoutMeasure =
-            new RendererCommon.VideoLayoutMeasure();
-    private final EglRenderer eglRenderer;
+  // Dedicated render thread.
+  private HandlerThread renderThread;
+  // |renderThreadHandler| is a handler for communicating with |renderThread|, and is synchronized
+  // on |handlerLock|.
+  private final Object handlerLock = new Object();
+  private Handler renderThreadHandler;
 
-    // Callback for reporting renderer events. Read-only after initilization so no lock required.
-    private RendererCommon.RendererEvents rendererEvents;
+  // EGL and GL resources for drawing YUV/OES textures. After initilization, these are only accessed
+  // from the render thread.
+  private EglBase eglBase;
+  private final RendererCommon.YuvUploader yuvUploader = new RendererCommon.YuvUploader();
+  private RendererCommon.GlDrawer drawer;
+  // Texture ids for YUV frames. Allocated on first arrival of a YUV frame.
+  private int[] yuvTextures = null;
 
-    private final Object layoutLock = new Object();
-    private boolean isRenderingPaused = false;
-    private boolean isFirstFrameRendered;
-    private int rotatedFrameWidth;
-    private int rotatedFrameHeight;
-    private int frameRotation;
+  // Pending frame to render. Serves as a queue with size 1. Synchronized on |frameLock|.
+  private final Object frameLock = new Object();
+  private VideoRenderer.I420Frame pendingFrame;
 
-    // Accessed only on the main thread.
-    private boolean enableFixedSize;
-    private int surfaceWidth;
-    private int surfaceHeight;
+  // These variables are synchronized on |layoutLock|.
+  private final Object layoutLock = new Object();
+  // These dimension values are used to keep track of the state in these functions: onMeasure(),
+  // onLayout(), and surfaceChanged(). A new layout is triggered with requestLayout(). This happens
+  // internally when the incoming frame size changes. requestLayout() can also be triggered
+  // externally. The layout change is a two pass process: first onMeasure() is called in a top-down
+  // traversal of the View tree, followed by an onLayout() pass that is also top-down. During the
+  // onLayout() pass, each parent is responsible for positioning its children using the sizes
+  // computed in the measure pass.
+  // |desiredLayoutsize| is the layout size we have requested in onMeasure() and are waiting for to
+  // take effect.
+  private Point desiredLayoutSize = new Point();
+  // |layoutSize|/|surfaceSize| is the actual current layout/surface size. They are updated in
+  // onLayout() and surfaceChanged() respectively.
+  private final Point layoutSize = new Point();
+  // TODO(magjed): Enable hardware scaler with SurfaceHolder.setFixedSize(). This will decouple
+  // layout and surface size.
+  private final Point surfaceSize = new Point();
+  // |isSurfaceCreated| keeps track of the current status in surfaceCreated()/surfaceDestroyed().
+  private boolean isSurfaceCreated;
+  // Last rendered frame dimensions, or 0 if no frame has been rendered yet.
+  private int frameWidth;
+  private int frameHeight;
+  private int frameRotation;
+  // |scalingType| determines how the video will fill the allowed layout area in onMeasure().
+  private RendererCommon.ScalingType scalingType = RendererCommon.ScalingType.SCALE_ASPECT_BALANCED;
+  // If true, mirrors the video stream horizontally.
+  private boolean mirror;
+  // Callback for reporting renderer events.
+  private RendererCommon.RendererEvents rendererEvents;
 
-    /**
-     * Standard View constructor. In order to render something, you must first call init().
-     */
-    public SurfaceViewRenderer(Context context) {
-        super(context);
-        this.resourceName = getResourceName();
-        eglRenderer = new EglRenderer(resourceName);
-        getHolder().addCallback(this);
+  // These variables are synchronized on |statisticsLock|.
+  private final Object statisticsLock = new Object();
+  // Total number of video frames received in renderFrame() call.
+  private int framesReceived;
+  // Number of video frames dropped by renderFrame() because previous frame has not been rendered
+  // yet.
+  private int framesDropped;
+  // Number of rendered video frames.
+  private int framesRendered;
+  // Time in ns when the first video frame was rendered.
+  private long firstFrameTimeNs;
+  // Time in ns spent in renderFrameOnRenderThread() function.
+  private long renderTimeNs;
+
+  // Runnable for posting frames to render thread.
+  private final Runnable renderFrameRunnable = new Runnable() {
+    @Override public void run() {
+      renderFrameOnRenderThread();
     }
-
-    /**
-     * Standard View constructor. In order to render something, you must first call init().
-     */
-    public SurfaceViewRenderer(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        this.resourceName = getResourceName();
-        eglRenderer = new EglRenderer(resourceName);
-        getHolder().addCallback(this);
+  };
+  // Runnable for clearing Surface to black.
+  private final Runnable makeBlackRunnable = new Runnable() {
+    @Override public void run() {
+      makeBlack();
     }
+  };
 
-    /**
-     * Initialize this class, sharing resources with |sharedContext|. It is allowed to call init() to
-     * reinitialize the renderer after a previous init()/release() cycle.
-     */
-    public void init(EglBase.Context sharedContext, RendererCommon.RendererEvents rendererEvents) {
-        init(sharedContext, rendererEvents, EglBase.CONFIG_PLAIN, new GlRectDrawer());
+  /**
+   * Standard View constructor. In order to render something, you must first call init().
+   */
+  public SurfaceViewRenderer(Context context) {
+    super(context);
+    getHolder().addCallback(this);
+  }
+
+  /**
+   * Standard View constructor. In order to render something, you must first call init().
+   */
+  public SurfaceViewRenderer(Context context, AttributeSet attrs) {
+    super(context, attrs);
+    getHolder().addCallback(this);
+  }
+
+  /**
+   * Initialize this class, sharing resources with |sharedContext|. It is allowed to call init() to
+   * reinitialize the renderer after a previous init()/release() cycle.
+   */
+  public void init(
+      EglBase.Context sharedContext, RendererCommon.RendererEvents rendererEvents) {
+    init(sharedContext, rendererEvents, EglBase.CONFIG_PLAIN, new GlRectDrawer());
+  }
+
+  /**
+   * Initialize this class, sharing resources with |sharedContext|. The custom |drawer| will be used
+   * for drawing frames on the EGLSurface. This class is responsible for calling release() on
+   * |drawer|. It is allowed to call init() to reinitialize the renderer after a previous
+   * init()/release() cycle.
+   */
+  public void init(EglBase.Context sharedContext, RendererCommon.RendererEvents rendererEvents,
+      int[] configAttributes, RendererCommon.GlDrawer drawer) {
+    synchronized (handlerLock) {
+      if (renderThreadHandler != null) {
+        throw new IllegalStateException(getResourceName() + "Already initialized");
+      }
+      Logging.d(TAG, getResourceName() + "Initializing.");
+      this.rendererEvents = rendererEvents;
+      this.drawer = drawer;
+      renderThread = new HandlerThread(TAG);
+      renderThread.start();
+      eglBase = EglBase.create(sharedContext, configAttributes);
+      renderThreadHandler = new Handler(renderThread.getLooper());
     }
+    tryCreateEglSurface();
+  }
 
-    /**
-     * Initialize this class, sharing resources with |sharedContext|. The custom |drawer| will be used
-     * for drawing frames on the EGLSurface. This class is responsible for calling release() on
-     * |drawer|. It is allowed to call init() to reinitialize the renderer after a previous
-     * init()/release() cycle.
-     */
-    public void init(final EglBase.Context sharedContext,
-                     RendererCommon.RendererEvents rendererEvents, final int[] configAttributes,
-                     RendererCommon.GlDrawer drawer) {
-        ThreadUtils.checkIsOnMainThread();
-        this.rendererEvents = rendererEvents;
+  /**
+   * Create and make an EGLSurface current if both init() and surfaceCreated() have been called.
+   */
+  public void tryCreateEglSurface() {
+    // |renderThreadHandler| is only created after |eglBase| is created in init(), so the
+    // following code will only execute if eglBase != null.
+    runOnRenderThread(new Runnable() {
+      @Override
+      public void run() {
         synchronized (layoutLock) {
-            isFirstFrameRendered = false;
-            rotatedFrameWidth = 0;
-            rotatedFrameHeight = 0;
-            frameRotation = 0;
+          if (eglBase != null && isSurfaceCreated && !eglBase.hasSurface()) {
+            eglBase.createSurface(getHolder().getSurface());
+            eglBase.makeCurrent();
+            // Necessary for YUV frames with odd width.
+            GLES20.glPixelStorei(GLES20.GL_UNPACK_ALIGNMENT, 1);
+          }
         }
-        eglRenderer.init(sharedContext, configAttributes, drawer);
+
+        // XXX by Saúl Ibarra Corretgé <saghul@gmail.com>: Until an actual frame
+        // is available to render, draw black; otherwise, this SurfaceView will
+        // appear transparent.
+        makeBlack();
+      }
+    });
+  }
+
+  /**
+   * Block until any pending frame is returned and all GL resources released, even if an interrupt
+   * occurs. If an interrupt occurs during release(), the interrupt flag will be set. This function
+   * should be called before the Activity is destroyed and the EGLContext is still valid. If you
+   * don't call this function, the GL resources might leak.
+   */
+  public void release() {
+    final CountDownLatch eglCleanupBarrier = new CountDownLatch(1);
+    synchronized (handlerLock) {
+      if (renderThreadHandler == null) {
+        Logging.d(TAG, getResourceName() + "Already released");
+        return;
+      }
+      // Release EGL and GL resources on render thread.
+      // TODO(magjed): This might not be necessary - all OpenGL resources are automatically deleted
+      // when the EGL context is lost. It might be dangerous to delete them manually in
+      // Activity.onDestroy().
+      renderThreadHandler.postAtFrontOfQueue(new Runnable() {
+        @Override public void run() {
+          drawer.release();
+          drawer = null;
+          if (yuvTextures != null) {
+            GLES20.glDeleteTextures(3, yuvTextures, 0);
+            yuvTextures = null;
+          }
+          // Clear last rendered image to black.
+          makeBlack();
+          eglBase.release();
+          eglBase = null;
+          eglCleanupBarrier.countDown();
+        }
+      });
+      // Don't accept any more frames or messages to the render thread.
+      renderThreadHandler = null;
+    }
+    // Make sure the EGL/GL cleanup posted above is executed.
+    ThreadUtils.awaitUninterruptibly(eglCleanupBarrier);
+    renderThread.quit();
+    synchronized (frameLock) {
+      if (pendingFrame != null) {
+        VideoRenderer.renderFrameDone(pendingFrame);
+        pendingFrame = null;
+      }
+    }
+    // The |renderThread| cleanup is not safe to cancel and we need to wait until it's done.
+    ThreadUtils.joinUninterruptibly(renderThread);
+    renderThread = null;
+    // Reset statistics and event reporting.
+    synchronized (layoutLock) {
+      frameWidth = 0;
+      frameHeight = 0;
+      frameRotation = 0;
+      rendererEvents = null;
+    }
+    resetStatistics();
+  }
+
+  /**
+   * Reset statistics. This will reset the logged statistics in logStatistics(), and
+   * RendererEvents.onFirstFrameRendered() will be called for the next frame.
+   */
+  public void resetStatistics() {
+    synchronized (statisticsLock) {
+      framesReceived = 0;
+      framesDropped = 0;
+      framesRendered = 0;
+      firstFrameTimeNs = 0;
+      renderTimeNs = 0;
+    }
+  }
+
+  /**
+   * Set if the video stream should be mirrored or not.
+   */
+  public void setMirror(final boolean mirror) {
+    synchronized (layoutLock) {
+      this.mirror = mirror;
+    }
+  }
+
+  /**
+   * Set how the video will fill the allowed layout area.
+   */
+  public void setScalingType(RendererCommon.ScalingType scalingType) {
+    synchronized (layoutLock) {
+      this.scalingType = scalingType;
+    }
+  }
+
+  // VideoRenderer.Callbacks interface.
+  @Override
+  public void renderFrame(VideoRenderer.I420Frame frame) {
+    synchronized (statisticsLock) {
+      ++framesReceived;
+    }
+    synchronized (handlerLock) {
+      if (renderThreadHandler == null) {
+        Logging.d(TAG, getResourceName()
+            + "Dropping frame - Not initialized or already released.");
+        VideoRenderer.renderFrameDone(frame);
+        return;
+      }
+      synchronized (frameLock) {
+        if (pendingFrame != null) {
+          // Drop old frame.
+          synchronized (statisticsLock) {
+            ++framesDropped;
+          }
+          VideoRenderer.renderFrameDone(pendingFrame);
+        }
+        pendingFrame = frame;
+        renderThreadHandler.post(renderFrameRunnable);
+      }
+    }
+  }
+
+  // Returns desired layout size given current measure specification and video aspect ratio.
+  private Point getDesiredLayoutSize(int widthSpec, int heightSpec) {
+    synchronized (layoutLock) {
+      final int maxWidth = getDefaultSize(Integer.MAX_VALUE, widthSpec);
+      final int maxHeight = getDefaultSize(Integer.MAX_VALUE, heightSpec);
+      final Point size =
+          RendererCommon.getDisplaySize(scalingType, frameAspectRatio(), maxWidth, maxHeight);
+      if (MeasureSpec.getMode(widthSpec) == MeasureSpec.EXACTLY) {
+        size.x = maxWidth;
+      }
+      if (MeasureSpec.getMode(heightSpec) == MeasureSpec.EXACTLY) {
+        size.y = maxHeight;
+      }
+      return size;
+    }
+  }
+
+  // View layout interface.
+  @Override
+  protected void onMeasure(int widthSpec, int heightSpec) {
+    final boolean isNewSize;
+    synchronized (layoutLock) {
+      if (frameWidth == 0 || frameHeight == 0) {
+        super.onMeasure(widthSpec, heightSpec);
+        return;
+      }
+      desiredLayoutSize = getDesiredLayoutSize(widthSpec, heightSpec);
+      isNewSize = (desiredLayoutSize.x != getMeasuredWidth()
+          || desiredLayoutSize.y != getMeasuredHeight());
+      setMeasuredDimension(desiredLayoutSize.x, desiredLayoutSize.y);
+    }
+    if (isNewSize) {
+      // Clear the surface asap before the layout change to avoid stretched video and other
+      // render artifacs. Don't wait for it to finish because the IO thread should never be
+      // blocked, so it's a best-effort attempt.
+      synchronized (handlerLock) {
+        if (renderThreadHandler != null) {
+          renderThreadHandler.postAtFrontOfQueue(makeBlackRunnable);
+        }
+      }
+    }
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    synchronized (layoutLock) {
+      layoutSize.x = right - left;
+      layoutSize.y = bottom - top;
+    }
+    // Might have a pending frame waiting for a layout of correct size.
+    runOnRenderThread(renderFrameRunnable);
+  }
+
+  // SurfaceHolder.Callback interface.
+  @Override
+  public void surfaceCreated(final SurfaceHolder holder) {
+    Logging.d(TAG, getResourceName() + "Surface created.");
+    synchronized (layoutLock) {
+      isSurfaceCreated = true;
+    }
+    tryCreateEglSurface();
+  }
+
+  @Override
+  public void surfaceDestroyed(SurfaceHolder holder) {
+    Logging.d(TAG, getResourceName() + "Surface destroyed.");
+    synchronized (layoutLock) {
+      isSurfaceCreated = false;
+      surfaceSize.x = 0;
+      surfaceSize.y = 0;
+    }
+    runOnRenderThread(new Runnable() {
+      @Override
+      public void run() {
+        if (eglBase != null) {
+          eglBase.detachCurrent();
+          eglBase.releaseSurface();
+        }
+      }
+    });
+  }
+
+  @Override
+  public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+    Logging.d(TAG, getResourceName() + "Surface changed: " + width + "x" + height);
+    synchronized (layoutLock) {
+      surfaceSize.x = width;
+      surfaceSize.y = height;
+    }
+    // Might have a pending frame waiting for a surface of correct size.
+    runOnRenderThread(renderFrameRunnable);
+  }
+
+  /**
+   * Private helper function to post tasks safely.
+   */
+  private void runOnRenderThread(Runnable runnable) {
+    synchronized (handlerLock) {
+      if (renderThreadHandler != null) {
+        renderThreadHandler.post(runnable);
+      }
+    }
+  }
+
+  private String getResourceName() {
+    try {
+      return getResources().getResourceEntryName(getId()) + ": ";
+    } catch (NotFoundException e) {
+      return "";
+    }
+  }
+
+  /**
+   * Post a task to clear the SurfaceView to a transparent uniform color.
+   */
+  public void clearImage() {}
+
+  private void makeBlack() {
+    if (Thread.currentThread() != renderThread) {
+      throw new IllegalStateException(getResourceName() + "Wrong thread.");
+    }
+    if (eglBase != null && eglBase.hasSurface()) {
+      GLES20.glClearColor(0, 0, 0, 0);
+      GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+      eglBase.swapBuffers();
+    }
+  }
+
+  /**
+   * Requests new layout if necessary. Returns true if layout and surface size are consistent.
+   */
+  private boolean checkConsistentLayout() {
+    if (Thread.currentThread() != renderThread) {
+      throw new IllegalStateException(getResourceName() + "Wrong thread.");
+    }
+    synchronized (layoutLock) {
+      // Return false while we are in the middle of a layout change.
+      // XXX by Lyubomir Marinov <lyubomir.marinov@jitsi.org>: Do not wait for
+      // layoutSize to become equal to desiredLayoutSize because that may never
+      // happen: desiredLayoutSize expresses the desire of this View computed
+      // during onMeasure but the final decision on layoutSize belongs to the
+      // ViewParent of this View taken around the execution time of onLayout. If
+      // this instance waits for the condition and its ViewParent does not
+      // satisfy the request for desiredLayoutSize, this SurfaceViewRenderer
+      // will render black.
+      return /* layoutSize.equals(desiredLayoutSize) && */ surfaceSize.equals(layoutSize);
+    }
+  }
+
+  /**
+   * Renders and releases |pendingFrame|.
+   */
+  private void renderFrameOnRenderThread() {
+    if (Thread.currentThread() != renderThread) {
+      throw new IllegalStateException(getResourceName() + "Wrong thread.");
+    }
+    // Fetch and render |pendingFrame|.
+    final VideoRenderer.I420Frame frame;
+    synchronized (frameLock) {
+      if (pendingFrame == null) {
+        return;
+      }
+      frame = pendingFrame;
+      pendingFrame = null;
+    }
+    updateFrameDimensionsAndReportEvents(frame);
+    if (eglBase == null || !eglBase.hasSurface()) {
+      Logging.d(TAG, getResourceName() + "No surface to draw on");
+      VideoRenderer.renderFrameDone(frame);
+      return;
+    }
+    if (!checkConsistentLayout()) {
+      // Output intermediate black frames while the layout is updated.
+      makeBlack();
+      VideoRenderer.renderFrameDone(frame);
+      return;
+    }
+    // After a surface size change, the EGLSurface might still have a buffer of the old size in the
+    // pipeline. Querying the EGLSurface will show if the underlying buffer dimensions haven't yet
+    // changed. Such a buffer will be rendered incorrectly, so flush it with a black frame.
+    synchronized (layoutLock) {
+      if (eglBase.surfaceWidth() != surfaceSize.x || eglBase.surfaceHeight() != surfaceSize.y) {
+        makeBlack();
+      }
     }
 
-    /**
-     * Block until any pending frame is returned and all GL resources released, even if an interrupt
-     * occurs. If an interrupt occurs during release(), the interrupt flag will be set. This function
-     * should be called before the Activity is destroyed and the EGLContext is still valid. If you
-     * don't call this function, the GL resources might leak.
-     */
-    public void release() {
-        eglRenderer.release();
+    final long startTimeNs = System.nanoTime();
+    final float[] texMatrix;
+    synchronized (layoutLock) {
+      final float[] rotatedSamplingMatrix =
+          RendererCommon.rotateTextureMatrix(frame.samplingMatrix, frame.rotationDegree);
+      final float[] layoutMatrix = RendererCommon.getLayoutMatrix(
+          mirror, frameAspectRatio(), (float) layoutSize.x / layoutSize.y);
+      texMatrix = RendererCommon.multiplyMatrices(rotatedSamplingMatrix, layoutMatrix);
     }
 
-    /**
-     * Register a callback to be invoked when a new video frame has been received.
-     *
-     * @param listener The callback to be invoked. The callback will be invoked on the render thread.
-     *                 It should be lightweight and must not call removeFrameListener.
-     * @param scale    The scale of the Bitmap passed to the callback, or 0 if no Bitmap is
-     *                 required.
-     * @param drawerParam   Custom drawer to use for this frame listener.
-     */
-    public void addFrameListener(
-            EglRenderer.FrameListener listener, float scale, RendererCommon.GlDrawer drawerParam) {
-        eglRenderer.addFrameListener(listener, scale, drawerParam);
+    // TODO(magjed): glClear() shouldn't be necessary since every pixel is covered anyway, but it's
+    // a workaround for bug 5147. Performance will be slightly worse.
+    GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+    if (frame.yuvFrame) {
+      // Make sure YUV textures are allocated.
+      if (yuvTextures == null) {
+        yuvTextures = new int[3];
+        for (int i = 0; i < 3; i++)  {
+          yuvTextures[i] = GlUtil.generateTexture(GLES20.GL_TEXTURE_2D);
+        }
+      }
+      yuvUploader.uploadYuvData(
+          yuvTextures, frame.width, frame.height, frame.yuvStrides, frame.yuvPlanes);
+      drawer.drawYuv(yuvTextures, texMatrix, frame.rotatedWidth(), frame.rotatedHeight(),
+          0, 0, surfaceSize.x, surfaceSize.y);
+    } else {
+      drawer.drawOes(frame.textureId, texMatrix, frame.rotatedWidth(), frame.rotatedHeight(),
+          0, 0, surfaceSize.x, surfaceSize.y);
     }
 
-    /**
-     * Register a callback to be invoked when a new video frame has been received. This version uses
-     * the drawer of the EglRenderer that was passed in init.
-     *
-     * @param listener The callback to be invoked. The callback will be invoked on the render thread.
-     *                 It should be lightweight and must not call removeFrameListener.
-     * @param scale    The scale of the Bitmap passed to the callback, or 0 if no Bitmap is
-     *                 required.
-     */
-    public void addFrameListener(EglRenderer.FrameListener listener, float scale) {
-        eglRenderer.addFrameListener(listener, scale);
-    }
-
-    public void removeFrameListener(EglRenderer.FrameListener listener) {
-        eglRenderer.removeFrameListener(listener);
-    }
-
-    /**
-     * Enables fixed size for the surface. This provides better performance but might be buggy on some
-     * devices. By default this is turned off.
-     */
-    public void setEnableHardwareScaler(boolean enabled) {
-        ThreadUtils.checkIsOnMainThread();
-        enableFixedSize = enabled;
-        updateSurfaceSize();
-    }
-
-    /**
-     * Set if the video stream should be mirrored or not.
-     */
-    public void setMirror(final boolean mirror) {
-        eglRenderer.setMirror(mirror);
-    }
-
-    /**
-     * Set how the video will fill the allowed layout area.
-     */
-    public void setScalingType(RendererCommon.ScalingType scalingType) {
-        ThreadUtils.checkIsOnMainThread();
-        videoLayoutMeasure.setScalingType(scalingType);
-        requestLayout();
-    }
-
-    public void setScalingType(RendererCommon.ScalingType scalingTypeMatchOrientation,
-                               RendererCommon.ScalingType scalingTypeMismatchOrientation) {
-        ThreadUtils.checkIsOnMainThread();
-        videoLayoutMeasure.setScalingType(scalingTypeMatchOrientation, scalingTypeMismatchOrientation);
-        requestLayout();
-    }
-
-    /**
-     * Limit render framerate.
-     *
-     * @param fps Limit render framerate to this value, or use Float.POSITIVE_INFINITY to disable fps
-     *            reduction.
-     */
-    public void setFpsReduction(float fps) {
+    eglBase.swapBuffers();
+    VideoRenderer.renderFrameDone(frame);
+    synchronized (statisticsLock) {
+      if (framesRendered == 0) {
+        firstFrameTimeNs = startTimeNs;
         synchronized (layoutLock) {
-            isRenderingPaused = fps == 0f;
+          Logging.d(TAG, getResourceName() + "Reporting first rendered frame.");
+          if (rendererEvents != null) {
+            rendererEvents.onFirstFrameRendered();
+          }
         }
-        eglRenderer.setFpsReduction(fps);
+      }
+      ++framesRendered;
+      renderTimeNs += (System.nanoTime() - startTimeNs);
+      if (framesRendered % 300 == 0) {
+        logStatistics();
+      }
     }
+  }
 
-    public void disableFpsReduction() {
-        synchronized (layoutLock) {
-            isRenderingPaused = false;
+  // Return current frame aspect ratio, taking rotation into account.
+  private float frameAspectRatio() {
+    synchronized (layoutLock) {
+      if (frameWidth == 0 || frameHeight == 0) {
+        return 0.0f;
+      }
+      return (frameRotation % 180 == 0) ? (float) frameWidth / frameHeight
+                                        : (float) frameHeight / frameWidth;
+    }
+  }
+
+  // Update frame dimensions and report any changes to |rendererEvents|.
+  private void updateFrameDimensionsAndReportEvents(VideoRenderer.I420Frame frame) {
+    synchronized (layoutLock) {
+      if (frameWidth != frame.width || frameHeight != frame.height
+          || frameRotation != frame.rotationDegree) {
+        Logging.d(TAG, getResourceName() + "Reporting frame resolution changed to "
+            + frame.width + "x" + frame.height + " with rotation " + frame.rotationDegree);
+        if (rendererEvents != null) {
+          rendererEvents.onFrameResolutionChanged(frame.width, frame.height, frame.rotationDegree);
         }
-        eglRenderer.disableFpsReduction();
-    }
-
-    public void pauseVideo() {
-        synchronized (layoutLock) {
-            isRenderingPaused = true;
-        }
-        eglRenderer.pauseVideo();
-    }
-
-    // VideoRenderer.Callbacks interface.
-    @Override
-    public void renderFrame(VideoRenderer.I420Frame frame) {
-        updateFrameDimensionsAndReportEvents(frame);
-        eglRenderer.renderFrame(frame);
-    }
-
-    // VideoSink interface.
-    @Override
-    public void onFrame(VideoFrame frame) {
-        updateFrameDimensionsAndReportEvents(frame);
-        eglRenderer.onFrame(frame);
-    }
-
-    // View layout interface.
-    @Override
-    protected void onMeasure(int widthSpec, int heightSpec) {
-        ThreadUtils.checkIsOnMainThread();
-        final Point size;
-        synchronized (layoutLock) {
-            size =
-                    videoLayoutMeasure.measure(widthSpec, heightSpec, rotatedFrameWidth, rotatedFrameHeight);
-        }
-        setMeasuredDimension(size.x, size.y);
-        logD("onMeasure(). New size: " + size.x + "x" + size.y);
-    }
-
-    @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        ThreadUtils.checkIsOnMainThread();
-        eglRenderer.setLayoutAspectRatio((right - left) / (float) (bottom - top));
-        updateSurfaceSize();
-    }
-
-    private void updateSurfaceSize() {
-        ThreadUtils.checkIsOnMainThread();
-        synchronized (layoutLock) {
-            if (enableFixedSize && rotatedFrameWidth != 0 && rotatedFrameHeight != 0 && getWidth() != 0
-                    && getHeight() != 0) {
-                final float layoutAspectRatio = getWidth() / (float) getHeight();
-                final float frameAspectRatio = rotatedFrameWidth / (float) rotatedFrameHeight;
-                final int drawnFrameWidth;
-                final int drawnFrameHeight;
-                if (frameAspectRatio > layoutAspectRatio) {
-                    drawnFrameWidth = (int) (rotatedFrameHeight * layoutAspectRatio);
-                    drawnFrameHeight = rotatedFrameHeight;
-                } else {
-                    drawnFrameWidth = rotatedFrameWidth;
-                    drawnFrameHeight = (int) (rotatedFrameWidth / layoutAspectRatio);
-                }
-                // Aspect ratio of the drawn frame and the view is the same.
-                final int width = Math.min(getWidth(), drawnFrameWidth);
-                final int height = Math.min(getHeight(), drawnFrameHeight);
-                logD("updateSurfaceSize. Layout size: " + getWidth() + "x" + getHeight() + ", frame size: "
-                        + rotatedFrameWidth + "x" + rotatedFrameHeight + ", requested surface size: " + width
-                        + "x" + height + ", old surface size: " + surfaceWidth + "x" + surfaceHeight);
-                if (width != surfaceWidth || height != surfaceHeight) {
-                    surfaceWidth = width;
-                    surfaceHeight = height;
-                    getHolder().setFixedSize(width, height);
-                }
-            } else {
-                surfaceWidth = surfaceHeight = 0;
-                getHolder().setSizeFromLayout();
-            }
-        }
-    }
-
-    // SurfaceHolder.Callback interface.
-    @Override
-    public void surfaceCreated(final SurfaceHolder holder) {
-        ThreadUtils.checkIsOnMainThread();
-        eglRenderer.createEglSurface(holder.getSurface());
-        surfaceWidth = surfaceHeight = 0;
-        updateSurfaceSize();
-    }
-
-    @Override
-    public void surfaceDestroyed(SurfaceHolder holder) {
-        ThreadUtils.checkIsOnMainThread();
-        final CountDownLatch completionLatch = new CountDownLatch(1);
-        eglRenderer.releaseEglSurface(new Runnable() {
-            @Override
-            public void run() {
-                completionLatch.countDown();
-            }
+        frameWidth = frame.width;
+        frameHeight = frame.height;
+        frameRotation = frame.rotationDegree;
+        post(new Runnable() {
+          @Override public void run() {
+            requestLayout();
+          }
         });
-        ThreadUtils.awaitUninterruptibly(completionLatch);
+      }
     }
+  }
 
-    @Override
-    public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-        ThreadUtils.checkIsOnMainThread();
-        logD("surfaceChanged: format: " + format + " size: " + width + "x" + height);
+  private void logStatistics() {
+    synchronized (statisticsLock) {
+      Logging.d(TAG, getResourceName() + "Frames received: "
+          + framesReceived + ". Dropped: " + framesDropped + ". Rendered: " + framesRendered);
+      if (framesReceived > 0 && framesRendered > 0) {
+        final long timeSinceFirstFrameNs = System.nanoTime() - firstFrameTimeNs;
+        Logging.d(TAG, getResourceName() + "Duration: " + (int) (timeSinceFirstFrameNs / 1e6) +
+            " ms. FPS: " + framesRendered * 1e9 / timeSinceFirstFrameNs);
+        Logging.d(TAG, getResourceName() + "Average render time: "
+            + (int) (renderTimeNs / (1000 * framesRendered)) + " us.");
+      }
     }
-
-    private String getResourceName() {
-        try {
-            return getResources().getResourceEntryName(getId()) + ": ";
-        } catch (NotFoundException e) {
-            return "";
-        }
-    }
-
-    /**
-     * Post a task to clear the SurfaceView to a transparent uniform color.
-     */
-    public void clearImage() {
-        eglRenderer.clearImage();
-    }
-
-    // Update frame dimensions and report any changes to |rendererEvents|.
-    private void updateFrameDimensionsAndReportEvents(VideoRenderer.I420Frame frame) {
-        synchronized (layoutLock) {
-            if (isRenderingPaused) {
-                return;
-            }
-            if (!isFirstFrameRendered) {
-                isFirstFrameRendered = true;
-                logD("Reporting first rendered frame.");
-                if (rendererEvents != null) {
-                    rendererEvents.onFirstFrameRendered();
-                }
-            }
-            if (rotatedFrameWidth != frame.rotatedWidth() || rotatedFrameHeight != frame.rotatedHeight()
-                    || frameRotation != frame.rotationDegree) {
-                logD("Reporting frame resolution changed to " + frame.width + "x" + frame.height
-                        + " with rotation " + frame.rotationDegree);
-                if (rendererEvents != null) {
-                    rendererEvents.onFrameResolutionChanged(frame.width, frame.height, frame.rotationDegree);
-                }
-                rotatedFrameWidth = frame.rotatedWidth();
-                rotatedFrameHeight = frame.rotatedHeight();
-                frameRotation = frame.rotationDegree;
-                post(new Runnable() {
-                    @Override
-                    public void run() {
-                        updateSurfaceSize();
-                        requestLayout();
-                    }
-                });
-            }
-        }
-    }
-
-    // Update frame dimensions and report any changes to |rendererEvents|.
-    private void updateFrameDimensionsAndReportEvents(VideoFrame frame) {
-        synchronized (layoutLock) {
-            if (isRenderingPaused) {
-                return;
-            }
-            if (!isFirstFrameRendered) {
-                isFirstFrameRendered = true;
-                logD("Reporting first rendered frame.");
-                if (rendererEvents != null) {
-                    rendererEvents.onFirstFrameRendered();
-                }
-            }
-            if (rotatedFrameWidth != frame.getRotatedWidth()
-                    || rotatedFrameHeight != frame.getRotatedHeight()
-                    || frameRotation != frame.getRotation()) {
-                logD("Reporting frame resolution changed to " + frame.getBuffer().getWidth() + "x"
-                        + frame.getBuffer().getHeight() + " with rotation " + frame.getRotation());
-                if (rendererEvents != null) {
-                    rendererEvents.onFrameResolutionChanged(
-                            frame.getBuffer().getWidth(), frame.getBuffer().getHeight(), frame.getRotation());
-                }
-                rotatedFrameWidth = frame.getRotatedWidth();
-                rotatedFrameHeight = frame.getRotatedHeight();
-                frameRotation = frame.getRotation();
-                post(new Runnable() {
-                    @Override
-                    public void run() {
-                        updateSurfaceSize();
-                        requestLayout();
-                    }
-                });
-            }
-        }
-    }
-
-    private void logD(String string) {
-        Logging.d(TAG, resourceName + string);
-    }
+  }
 }

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModulePackage.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModulePackage.java
@@ -25,11 +25,6 @@ public class WebRTCModulePackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
             new RTCVideoViewManager()

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -2,6 +2,7 @@ package com.oney.WebRTCModule;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.graphics.Color;
 import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,6 +21,12 @@ import org.webrtc.RendererCommon.RendererEvents;
 import org.webrtc.RendererCommon.ScalingType;
 import org.webrtc.VideoRenderer;
 import org.webrtc.VideoTrack;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 public class WebRTCView extends ViewGroup {
     /**
@@ -105,6 +112,7 @@ public class WebRTCView extends ViewGroup {
         = new RendererEvents() {
             @Override
             public void onFirstFrameRendered() {
+                WebRTCView.this.onFirstFrameRendered();
             }
 
             @Override
@@ -233,6 +241,30 @@ public class WebRTCView extends ViewGroup {
         } finally {
             super.onDetachedFromWindow();
         }
+    }
+
+    /**
+     * Callback fired by {@link #surfaceViewRenderer} when the first frame is
+     * rendered. Here we will set the background of the view part of the
+     * SurfaceView to transparent, so the surface (where video is actually
+     * rendered) shines through.
+     */
+    private void onFirstFrameRendered() {
+        post(new Runnable() {
+            @Override
+            public void run() {
+                Log.d(TAG, "First frame rendered.");
+
+                WritableMap event = Arguments.createMap();
+                ReactContext reactContext = (ReactContext) getContext();
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+                        getId(),
+                        "onFirstFrame",
+                        event
+                );
+                getSurfaceViewRenderer().setBackgroundColor(Color.TRANSPARENT);
+            }
+        });
     }
 
     /**

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -7,7 +7,6 @@ import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewGroup;
 import android.util.Log;
-import android.view.animation.AnimationUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -31,57 +30,15 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 import static android.os.Build.VERSION.SDK_INT;
 
-
-class Throttle {
-
-    private long mLastFiredTimestamp;
-    private long mInterval;
-
-    public Throttle(long interval) {
-        mInterval = interval;
-    }
-
-    public void attempt(Runnable runnable) {
-        if (hasSatisfiedInterval()) {
-            runnable.run();
-            mLastFiredTimestamp = getNow();
-        }
-    }
-
-    private boolean hasSatisfiedInterval() {
-        long elapsed = getNow() - mLastFiredTimestamp;
-        return elapsed >= mInterval;
-    }
-
-    private long getNow() {
-        return AnimationUtils.currentAnimationTimeMillis();
-    }
-
-}
-
-class Debounce {
-
-    private Handler mHandler = new Handler();
-    private long mInterval;
-
-    public Debounce(long interval) {
-        mInterval = interval;
-    }
-
-    public void attempt(Runnable runnable) {
-        mHandler.removeCallbacks(runnable);
-        mHandler.postDelayed(runnable, mInterval);
-    }
-
-}
-
 public class WebRTCView extends ViewGroup {
+
+    public final boolean isSurfaceRendererWorksFine = SDK_INT > 23;
     /**
      * The scaling type to be utilized by default.
-     * <p>
+     *
      * The default value is in accord with
      * https://www.w3.org/TR/html5/embedded-content-0.html#the-video-element:
-     * <p>
+     *
      * In the absence of style rules to the contrary, video content should be
      * rendered inside the element's playback area such that the video content
      * is shown centered in the playback area at the largest possible size that
@@ -92,7 +49,7 @@ public class WebRTCView extends ViewGroup {
      * video represent nothing.
      */
     private static final ScalingType DEFAULT_SCALING_TYPE
-            = ScalingType.SCALE_ASPECT_FIT;
+        = ScalingType.SCALE_ASPECT_FIT;
 
     /**
      * {@link View#isInLayout()} as a <tt>Method</tt> to be invoked via
@@ -122,19 +79,19 @@ public class WebRTCView extends ViewGroup {
 
     /**
      * The height of the last video frame rendered by
-     * {@link #surfaceViewRenderer}.
+     * {@link #renderer}.
      */
     private int frameHeight;
 
     /**
      * The rotation (degree) of the last video frame rendered by
-     * {@link #surfaceViewRenderer}.
+     * {@link #renderer}.
      */
     private int frameRotation;
 
     /**
      * The width of the last video frame rendered by
-     * {@link #surfaceViewRenderer}.
+     * {@link #renderer}.
      */
     private int frameWidth;
 
@@ -153,24 +110,24 @@ public class WebRTCView extends ViewGroup {
 
     /**
      * The {@code RendererEvents} which listens to rendering events reported by
-     * {@link #surfaceViewRenderer}.
+     * {@link #renderer}.
      */
     private final RendererEvents rendererEvents
-            = new RendererEvents() {
-        @Override
-        public void onFirstFrameRendered() {
-            WebRTCView.this.onFirstFrameRendered();
-        }
+        = new RendererEvents() {
+            @Override
+            public void onFirstFrameRendered() {
+                WebRTCView.this.onFirstFrameRendered();
+            }
 
-        @Override
-        public void onFrameResolutionChanged(
-                int videoWidth, int videoHeight,
-                int rotation) {
-            WebRTCView.this.onFrameResolutionChanged(
-                    videoWidth, videoHeight,
-                    rotation);
-        }
-    };
+            @Override
+            public void onFrameResolutionChanged(
+                    int videoWidth, int videoHeight,
+                    int rotation) {
+                WebRTCView.this.onFrameResolutionChanged(
+                        videoWidth, videoHeight,
+                        rotation);
+            }
+        };
 
     /**
      * The {@code Runnable} representation of
@@ -179,12 +136,12 @@ public class WebRTCView extends ViewGroup {
      * initializing new instances on every (method) call.
      */
     private final Runnable requestSurfaceViewRendererLayoutRunnable
-            = new Runnable() {
-        @Override
-        public void run() {
-            requestSurfaceViewRendererLayout();
-        }
-    };
+        = new Runnable() {
+            @Override
+            public void run() {
+                requestSurfaceViewRendererLayout();
+            }
+        };
 
     /**
      * The scaling type this {@code WebRTCView} is to apply to the video
@@ -197,7 +154,7 @@ public class WebRTCView extends ViewGroup {
      * The {@link View} and {@link VideoRenderer#Callbacks} implementation which
      * actually renders {@link #videoTrack} on behalf of this instance.
      */
-    private final SurfaceViewRenderer surfaceViewRenderer;
+    private final IRenderer renderer;
 
     /**
      * The {@code VideoRenderer}, if any, which renders {@link #videoTrack} on
@@ -213,8 +170,9 @@ public class WebRTCView extends ViewGroup {
     public WebRTCView(Context context) {
         super(context);
 
-        surfaceViewRenderer = new SurfaceViewRenderer(context);
-        addView(surfaceViewRenderer);
+
+        renderer = isSurfaceRendererWorksFine ? new SurfaceViewRenderer(context) : new TextureViewRenderer(context);
+        addView((View)renderer);
 
         setMirror(false);
         setScalingType(DEFAULT_SCALING_TYPE);
@@ -242,6 +200,7 @@ public class WebRTCView extends ViewGroup {
      * @return If this <tt>View</tt> has <tt>View#isInLayout()</tt>, invokes it
      * and returns its return value; otherwise, returns <tt>false</tt>.
      */
+    @TargetApi(Build.VERSION_CODES.KITKAT)
     private boolean invokeIsInLayout() {
         Method m = IS_IN_LAYOUT;
         boolean b = false;
@@ -290,29 +249,8 @@ public class WebRTCView extends ViewGroup {
         }
     }
 
-    private Debounce mThrottle = new Debounce(100);
-
-    @Override
-    public void setScaleX(final float scaleX) {
-        if (SDK_INT < 24) {
-            final WebRTCView self = this;
-
-            final int l = self.getLeft();
-            final int t = self.getTop();
-            final int r = self.getRight();
-            final int b = self.getBottom();
-
-            final int w = Math.round((r - l) * scaleX);
-            final int h = Math.round((b - t) * scaleX);
-
-            self.onLayout(true, 0, 0, w, h);
-            Log.d("###", "" + scaleX);
-        }
-        super.setScaleX(scaleX);
-    }
-
     /**
-     * Callback fired by {@link #surfaceViewRenderer} when the first frame is
+     * Callback fired by {@link #renderer} when the first frame is
      * rendered. Here we will set the background of the view part of the
      * SurfaceView to transparent, so the surface (where video is actually
      * rendered) shines through.
@@ -330,18 +268,18 @@ public class WebRTCView extends ViewGroup {
                         "onFirstFrame",
                         event
                 );
-                getSurfaceViewRenderer().setBackgroundColor(Color.TRANSPARENT);
+                getRenderer().setBackgroundColor(Color.TRANSPARENT);
             }
         });
     }
 
     /**
-     * Callback fired by {@link #surfaceViewRenderer} when the resolution or
+     * Callback fired by {@link #renderer} when the resolution or
      * rotation of the frame it renders has changed.
      *
-     * @param videoWidth  The new width of the rendered video frame.
+     * @param videoWidth The new width of the rendered video frame.
      * @param videoHeight The new height of the rendered video frame.
-     * @param rotation    The new rotation of the rendered video frame.
+     * @param rotation The new rotation of the rendered video frame.
      */
     private void onFrameResolutionChanged(
             int videoWidth, int videoHeight,
@@ -395,41 +333,41 @@ public class WebRTCView extends ViewGroup {
             SurfaceViewRenderer surfaceViewRenderer = getSurfaceViewRenderer();
 
             switch (scalingType) {
-                case SCALE_ASPECT_FILL:
-                    // Fill this ViewGroup with surfaceViewRenderer and the latter
-                    // will take care of filling itself with the video similarly to
-                    // the cover value the CSS property object-fit.
-                    r = width;
-                    l = 0;
-                    b = height;
-                    t = 0;
-                    break;
-                case SCALE_ASPECT_FIT:
-                default:
-                    // Lay surfaceViewRenderer out inside this ViewGroup in accord
-                    // with the contain value of the CSS property object-fit.
-                    // SurfaceViewRenderer will fill itself with the video similarly
-                    // to the cover or contain value of the CSS property object-fit
-                    // (which will not matter, eventually).
-                    if (frameHeight == 0 || frameWidth == 0) {
-                        l = t = r = b = 0;
-                    } else {
-                        float frameAspectRatio
-                                = (frameRotation % 180 == 0)
-                                ? frameWidth / (float) frameHeight
-                                : frameHeight / (float) frameWidth;
-                        Point frameDisplaySize
-                                = RendererCommon.getDisplaySize(
+            case SCALE_ASPECT_FILL:
+                // Fill this ViewGroup with surfaceViewRenderer and the latter
+                // will take care of filling itself with the video similarly to
+                // the cover value the CSS property object-fit.
+                r = width;
+                l = 0;
+                b = height;
+                t = 0;
+                break;
+            case SCALE_ASPECT_FIT:
+            default:
+                // Lay surfaceViewRenderer out inside this ViewGroup in accord
+                // with the contain value of the CSS property object-fit.
+                // SurfaceViewRenderer will fill itself with the video similarly
+                // to the cover or contain value of the CSS property object-fit
+                // (which will not matter, eventually).
+                if (frameHeight == 0 || frameWidth == 0) {
+                    l = t = r = b = 0;
+                } else {
+                    float frameAspectRatio
+                        = (frameRotation % 180 == 0)
+                            ? frameWidth / (float) frameHeight
+                            : frameHeight / (float) frameWidth;
+                    Point frameDisplaySize
+                        = RendererCommon.getDisplaySize(
                                 scalingType,
                                 frameAspectRatio,
                                 width, height);
 
-                        l = (width - frameDisplaySize.x) / 2;
-                        t = (height - frameDisplaySize.y) / 2;
-                        r = l + frameDisplaySize.x;
-                        b = t + frameDisplaySize.y;
-                    }
-                    break;
+                    l = (width - frameDisplaySize.x) / 2;
+                    t = (height - frameDisplaySize.y) / 2;
+                    r = l + frameDisplaySize.x;
+                    b = t + frameDisplaySize.y;
+                }
+                break;
             }
         }
         surfaceViewRenderer.layout(l, t, r, b);
@@ -445,7 +383,7 @@ public class WebRTCView extends ViewGroup {
             videoRenderer.dispose();
             videoRenderer = null;
 
-            getSurfaceViewRenderer().release();
+            getRenderer().release();
 
             // Since this WebRTCView is no longer rendering anything, make sure
             // surfaceViewRenderer displays nothing as well.
@@ -459,20 +397,20 @@ public class WebRTCView extends ViewGroup {
     }
 
     /**
-     * Request that {@link #surfaceViewRenderer} be laid out (as soon as
+     * Request that {@link #renderer} be laid out (as soon as
      * possible) because layout-related state either of this instance or of
      * {@code surfaceViewRenderer} has changed.
      */
     private void requestSurfaceViewRendererLayout() {
         // Google/WebRTC just call requestLayout() on surfaceViewRenderer when
         // they change the value of its mirror or surfaceType property. 
-        getSurfaceViewRenderer().requestLayout();
+        getRenderer().requestLayout();
         // The above is not enough though when the video frame's dimensions or
         // rotation change. The following will suffice.
         if (!invokeIsInLayout()) {
             onLayout(
-                    /* changed */ false,
-                    getLeft(), getTop(), getRight(), getBottom());
+                /* changed */ false,
+                getLeft(), getTop(), getRight(), getBottom());
         }
     }
 
@@ -481,16 +419,16 @@ public class WebRTCView extends ViewGroup {
      * mirror the video represented by {@link #videoTrack} during its rendering.
      *
      * @param mirror If this {@code WebRTCView} is to mirror the video
-     *               represented by {@code videoTrack} during its rendering, {@code true};
-     *               otherwise, {@code false}.
+     * represented by {@code videoTrack} during its rendering, {@code true};
+     * otherwise, {@code false}.
      */
     public void setMirror(boolean mirror) {
         if (this.mirror != mirror) {
             this.mirror = mirror;
 
-            SurfaceViewRenderer surfaceViewRenderer = getSurfaceViewRenderer();
+            IRenderer renderer = getRenderer();
 
-            surfaceViewRenderer.setMirror(mirror);
+            renderer.setMirror(mirror);
             // SurfaceViewRenderer takes the value of its mirror property into
             // account upon its layout.
             requestSurfaceViewRendererLayout();
@@ -504,12 +442,12 @@ public class WebRTCView extends ViewGroup {
      * resembles the CSS style {@code object-fit}.
      *
      * @param objectFit For details, refer to the documentation of the
-     *                  {@code objectFit} property of the JavaScript counterpart of
-     *                  {@code WebRTCView} i.e. {@code RTCView}.
+     * {@code objectFit} property of the JavaScript counterpart of
+     * {@code WebRTCView} i.e. {@code RTCView}.
      */
     public void setObjectFit(String objectFit) {
         ScalingType scalingType
-                = "cover".equals(objectFit)
+            = "cover".equals(objectFit)
                 ? ScalingType.SCALE_ASPECT_FILL
                 : ScalingType.SCALE_ASPECT_FIT;
 
@@ -517,7 +455,7 @@ public class WebRTCView extends ViewGroup {
     }
 
     private void setScalingType(ScalingType scalingType) {
-        SurfaceViewRenderer surfaceViewRenderer;
+        IRenderer renderer;
 
         synchronized (layoutSyncRoot) {
             if (this.scalingType == scalingType) {
@@ -526,8 +464,8 @@ public class WebRTCView extends ViewGroup {
 
             this.scalingType = scalingType;
 
-            surfaceViewRenderer = getSurfaceViewRenderer();
-            surfaceViewRenderer.setScalingType(scalingType);
+            renderer = getRenderer();
+            renderer.setScalingType(scalingType);
         }
         // Both this instance ant its SurfaceViewRenderer take the value of
         // their scalingType properties into account upon their layouts.
@@ -560,7 +498,7 @@ public class WebRTCView extends ViewGroup {
      * Sets the {@code VideoTrack} to be rendered by this {@code WebRTCView}.
      *
      * @param videoTrack The {@code VideoTrack} to be rendered by this
-     *                   {@code WebRTCView} or {@code null}.
+     * {@code WebRTCView} or {@code null}.
      */
     private void setVideoTrack(VideoTrack videoTrack) {
         VideoTrack oldValue = this.videoTrack;

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -78,10 +78,10 @@ class Debounce {
 public class WebRTCView extends ViewGroup {
     /**
      * The scaling type to be utilized by default.
-     *
+     * <p>
      * The default value is in accord with
      * https://www.w3.org/TR/html5/embedded-content-0.html#the-video-element:
-     *
+     * <p>
      * In the absence of style rules to the contrary, video content should be
      * rendered inside the element's playback area such that the video content
      * is shown centered in the playback area at the largest possible size that
@@ -92,7 +92,7 @@ public class WebRTCView extends ViewGroup {
      * video represent nothing.
      */
     private static final ScalingType DEFAULT_SCALING_TYPE
-        = ScalingType.SCALE_ASPECT_FIT;
+            = ScalingType.SCALE_ASPECT_FIT;
 
     /**
      * {@link View#isInLayout()} as a <tt>Method</tt> to be invoked via
@@ -156,21 +156,21 @@ public class WebRTCView extends ViewGroup {
      * {@link #surfaceViewRenderer}.
      */
     private final RendererEvents rendererEvents
-        = new RendererEvents() {
-            @Override
-            public void onFirstFrameRendered() {
-                WebRTCView.this.onFirstFrameRendered();
-            }
+            = new RendererEvents() {
+        @Override
+        public void onFirstFrameRendered() {
+            WebRTCView.this.onFirstFrameRendered();
+        }
 
-            @Override
-            public void onFrameResolutionChanged(
-                    int videoWidth, int videoHeight,
-                    int rotation) {
-                WebRTCView.this.onFrameResolutionChanged(
-                        videoWidth, videoHeight,
-                        rotation);
-            }
-        };
+        @Override
+        public void onFrameResolutionChanged(
+                int videoWidth, int videoHeight,
+                int rotation) {
+            WebRTCView.this.onFrameResolutionChanged(
+                    videoWidth, videoHeight,
+                    rotation);
+        }
+    };
 
     /**
      * The {@code Runnable} representation of
@@ -179,12 +179,12 @@ public class WebRTCView extends ViewGroup {
      * initializing new instances on every (method) call.
      */
     private final Runnable requestSurfaceViewRendererLayoutRunnable
-        = new Runnable() {
-            @Override
-            public void run() {
-                requestSurfaceViewRendererLayout();
-            }
-        };
+            = new Runnable() {
+        @Override
+        public void run() {
+            requestSurfaceViewRendererLayout();
+        }
+    };
 
     /**
      * The scaling type this {@code WebRTCView} is to apply to the video
@@ -297,21 +297,16 @@ public class WebRTCView extends ViewGroup {
         if (SDK_INT < 24) {
             final WebRTCView self = this;
 
-            mThrottle.attempt(new Runnable() {
-                @Override
-                public void run() {
-                    final int l = self.getLeft();
-                    final int t = self.getTop();
-                    final int r = self.getRight();
-                    final int b = self.getBottom();
+            final int l = self.getLeft();
+            final int t = self.getTop();
+            final int r = self.getRight();
+            final int b = self.getBottom();
 
-                    final int w = Math.round((r-l) * scaleX);
-                    final int h = Math.round((b-t) * scaleX);
+            final int w = Math.round((r - l) * scaleX);
+            final int h = Math.round((b - t) * scaleX);
 
-                    self.onLayout(true, 0, 0, w, h);
-                    Log.d("###", ""+scaleX);
-                }
-            });
+            self.onLayout(true, 0, 0, w, h);
+            Log.d("###", "" + scaleX);
         }
         super.setScaleX(scaleX);
     }
@@ -344,9 +339,9 @@ public class WebRTCView extends ViewGroup {
      * Callback fired by {@link #surfaceViewRenderer} when the resolution or
      * rotation of the frame it renders has changed.
      *
-     * @param videoWidth The new width of the rendered video frame.
+     * @param videoWidth  The new width of the rendered video frame.
      * @param videoHeight The new height of the rendered video frame.
-     * @param rotation The new rotation of the rendered video frame.
+     * @param rotation    The new rotation of the rendered video frame.
      */
     private void onFrameResolutionChanged(
             int videoWidth, int videoHeight,
@@ -400,41 +395,41 @@ public class WebRTCView extends ViewGroup {
             SurfaceViewRenderer surfaceViewRenderer = getSurfaceViewRenderer();
 
             switch (scalingType) {
-            case SCALE_ASPECT_FILL:
-                // Fill this ViewGroup with surfaceViewRenderer and the latter
-                // will take care of filling itself with the video similarly to
-                // the cover value the CSS property object-fit.
-                r = width;
-                l = 0;
-                b = height;
-                t = 0;
-                break;
-            case SCALE_ASPECT_FIT:
-            default:
-                // Lay surfaceViewRenderer out inside this ViewGroup in accord
-                // with the contain value of the CSS property object-fit.
-                // SurfaceViewRenderer will fill itself with the video similarly
-                // to the cover or contain value of the CSS property object-fit
-                // (which will not matter, eventually).
-                if (frameHeight == 0 || frameWidth == 0) {
-                    l = t = r = b = 0;
-                } else {
-                    float frameAspectRatio
-                        = (frameRotation % 180 == 0)
-                            ? frameWidth / (float) frameHeight
-                            : frameHeight / (float) frameWidth;
-                    Point frameDisplaySize
-                        = RendererCommon.getDisplaySize(
+                case SCALE_ASPECT_FILL:
+                    // Fill this ViewGroup with surfaceViewRenderer and the latter
+                    // will take care of filling itself with the video similarly to
+                    // the cover value the CSS property object-fit.
+                    r = width;
+                    l = 0;
+                    b = height;
+                    t = 0;
+                    break;
+                case SCALE_ASPECT_FIT:
+                default:
+                    // Lay surfaceViewRenderer out inside this ViewGroup in accord
+                    // with the contain value of the CSS property object-fit.
+                    // SurfaceViewRenderer will fill itself with the video similarly
+                    // to the cover or contain value of the CSS property object-fit
+                    // (which will not matter, eventually).
+                    if (frameHeight == 0 || frameWidth == 0) {
+                        l = t = r = b = 0;
+                    } else {
+                        float frameAspectRatio
+                                = (frameRotation % 180 == 0)
+                                ? frameWidth / (float) frameHeight
+                                : frameHeight / (float) frameWidth;
+                        Point frameDisplaySize
+                                = RendererCommon.getDisplaySize(
                                 scalingType,
                                 frameAspectRatio,
                                 width, height);
 
-                    l = (width - frameDisplaySize.x) / 2;
-                    t = (height - frameDisplaySize.y) / 2;
-                    r = l + frameDisplaySize.x;
-                    b = t + frameDisplaySize.y;
-                }
-                break;
+                        l = (width - frameDisplaySize.x) / 2;
+                        t = (height - frameDisplaySize.y) / 2;
+                        r = l + frameDisplaySize.x;
+                        b = t + frameDisplaySize.y;
+                    }
+                    break;
             }
         }
         surfaceViewRenderer.layout(l, t, r, b);
@@ -486,8 +481,8 @@ public class WebRTCView extends ViewGroup {
      * mirror the video represented by {@link #videoTrack} during its rendering.
      *
      * @param mirror If this {@code WebRTCView} is to mirror the video
-     * represented by {@code videoTrack} during its rendering, {@code true};
-     * otherwise, {@code false}.
+     *               represented by {@code videoTrack} during its rendering, {@code true};
+     *               otherwise, {@code false}.
      */
     public void setMirror(boolean mirror) {
         if (this.mirror != mirror) {
@@ -509,12 +504,12 @@ public class WebRTCView extends ViewGroup {
      * resembles the CSS style {@code object-fit}.
      *
      * @param objectFit For details, refer to the documentation of the
-     * {@code objectFit} property of the JavaScript counterpart of
-     * {@code WebRTCView} i.e. {@code RTCView}.
+     *                  {@code objectFit} property of the JavaScript counterpart of
+     *                  {@code WebRTCView} i.e. {@code RTCView}.
      */
     public void setObjectFit(String objectFit) {
         ScalingType scalingType
-            = "cover".equals(objectFit)
+                = "cover".equals(objectFit)
                 ? ScalingType.SCALE_ASPECT_FILL
                 : ScalingType.SCALE_ASPECT_FIT;
 
@@ -565,7 +560,7 @@ public class WebRTCView extends ViewGroup {
      * Sets the {@code VideoTrack} to be rendered by this {@code WebRTCView}.
      *
      * @param videoTrack The {@code VideoTrack} to be rendered by this
-     * {@code WebRTCView} or {@code null}.
+     *                   {@code WebRTCView} or {@code null}.
      */
     private void setVideoTrack(VideoTrack videoTrack) {
         VideoTrack oldValue = this.videoTrack;

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCView.java
@@ -1,8 +1,10 @@
 package com.oney.WebRTCModule;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Point;
 import android.graphics.Color;
+import android.os.Build;
 import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.ViewGroup;
@@ -188,8 +190,8 @@ public class WebRTCView extends ViewGroup {
      *
      * @return The {@code SurfaceViewRenderer} which renders {@code videoTrack}.
      */
-    private final SurfaceViewRenderer getSurfaceViewRenderer() {
-        return surfaceViewRenderer;
+    private final IRenderer getRenderer() {
+        return renderer;
     }
 
     /**
@@ -330,8 +332,6 @@ public class WebRTCView extends ViewGroup {
                 scalingType = this.scalingType;
             }
 
-            SurfaceViewRenderer surfaceViewRenderer = getSurfaceViewRenderer();
-
             switch (scalingType) {
             case SCALE_ASPECT_FILL:
                 // Fill this ViewGroup with surfaceViewRenderer and the latter
@@ -370,7 +370,7 @@ public class WebRTCView extends ViewGroup {
                 break;
             }
         }
-        surfaceViewRenderer.layout(l, t, r, b);
+        getRenderer().layout(l, t, r, b);
     }
 
     /**
@@ -525,17 +525,17 @@ public class WebRTCView extends ViewGroup {
      * @param zOrder The z-order to set on this {@code WebRTCView}.
      */
     public void setZOrder(int zOrder) {
-        SurfaceViewRenderer surfaceViewRenderer = getSurfaceViewRenderer();
+        IRenderer renderer = getRenderer();
 
         switch (zOrder) {
         case 0:
-            surfaceViewRenderer.setZOrderMediaOverlay(false);
+            renderer.setZOrderMediaOverlay(false);
             break;
         case 1:
-            surfaceViewRenderer.setZOrderMediaOverlay(true);
+            renderer.setZOrderMediaOverlay(true);
             break;
         case 2:
-            surfaceViewRenderer.setZOrderOnTop(true);
+            renderer.setZOrderOnTop(true);
             break;
         }
     }
@@ -548,7 +548,7 @@ public class WebRTCView extends ViewGroup {
         if (videoRenderer == null
                 && videoTrack != null
                 && ViewCompat.isAttachedToWindow(this)) {
-            SurfaceViewRenderer surfaceViewRenderer = getSurfaceViewRenderer();
+            IRenderer renderer = getRenderer();
 
             // XXX EglBase14 will report that isEGL14Supported() but its
             // getEglConfig() will fail with a RuntimeException with message
@@ -591,9 +591,9 @@ public class WebRTCView extends ViewGroup {
             // EglBase implementation to utilize.
             EglBase.Context sharedContext = eglBase.getEglBaseContext();
 
-            surfaceViewRenderer.init(sharedContext, rendererEvents);
+            renderer.init(sharedContext, rendererEvents);
 
-            videoRenderer = new VideoRenderer(surfaceViewRenderer);
+            videoRenderer = new VideoRenderer(renderer);
             videoTrack.addRenderer(videoRenderer);
         }
     }

--- a/ios/RCTWebRTC/RTCVideoViewManager.m
+++ b/ios/RCTWebRTC/RTCVideoViewManager.m
@@ -45,6 +45,8 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  */
 @interface RTCVideoView : UIView <RTCVideoRenderer, RTCEAGLVideoViewDelegate>
 
+@property (nonatomic, copy) RCTDirectEventBlock onFirstFrame;
+
 /**
  * The indicator which determines whether this {@code RTCVideoView} is to mirror
  * the video specified by {@link #videoTrack} during its rendering. Typically,
@@ -79,6 +81,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
   /**
    * The width and height of the video (frames) rendered by {@link #subview}.
    */
+    BOOL firstFrameRendered;
   CGSize _videoSize;
 }
 
@@ -87,6 +90,7 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  */
 - (void)didMoveToWindow {
   [super didMoveToWindow];
+    firstFrameRendered = NO;
 
   // XXX This RTCVideoView strongly retains its videoTrack. The latter strongly
   // retains the former as well though because RTCVideoTrack strongly retains
@@ -298,6 +302,10 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
  */
 - (void)renderFrame:(RTCVideoFrame *)frame {
   id<RTCVideoRenderer> videoRenderer = self.subview;
+    if (!firstFrameRendered) {
+        firstFrameRendered = YES;
+        self.onFirstFrame(@{});
+    }
   if (videoRenderer) {
     [videoRenderer renderFrame:frame];
   }
@@ -339,6 +347,8 @@ typedef NS_ENUM(NSInteger, RTCVideoViewObjectFit) {
 @implementation RTCVideoViewManager
 
 RCT_EXPORT_MODULE()
+
+RCT_EXPORT_VIEW_PROPERTY(onFirstFrame, RCTDirectEventBlock)
 
 - (UIView *)view {
   RTCVideoView *v = [[RTCVideoView alloc] init];

--- a/ios/RCTWebRTC/WebRTCModule.m
+++ b/ios/RCTWebRTC/WebRTCModule.m
@@ -52,6 +52,11 @@
   _peerConnectionFactory = nil;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_MODULE();
 
 - (dispatch_queue_t)methodQueue

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "base64-js": "^1.1.2",
-    "event-target-shim": "^1.0.5"
+    "event-target-shim": "^1.0.5",
+    "prop-types": "^15.5.7"
   },
   "peerDependencies": {
     "react-native": ">=0.40.0"


### PR DESCRIPTION
* Create a new fork of `react-native-webrtc` that preserves the original repo history.
* Use `react-native-webrtc` 1.57.1 as baseline.
* Adapt that version to work with current React and React Native.
* Cherry-pick Hive fixes on top of that.
