### PR TITLE
Lower pod minimum deployment target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "1.75.0-hive-1",
+  "version": "1.75.0-hive-2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"

--- a/react-native-webrtc.podspec
+++ b/react-native-webrtc.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source              = { :git => 'git@github.com:react-native-webrtc/react-native-webrtc.git', :tag => 'release #{s.version}' }
   s.requires_arc        = true
 
-  s.platform            = :ios, '10.0'
+  s.platform            = :ios, '9.0'
 
   s.preserve_paths      = 'ios/**/*'
   s.source_files        = 'ios/**/*.{h,m}'


### PR DESCRIPTION
There is an error happening during `pod install` related to the minimum deployment target. As all the other packages work well targeting `9.0` it seems to be a safe change.

<img width="638" alt="Screenshot 2019-08-20 at 10 04 27" src="https://user-images.githubusercontent.com/6296883/63338889-9d3cb900-c33b-11e9-929b-257e30681dd0.png">
