### PR TITLE
MA1-418: [Android 10/11]Live streaming volume is very low as it is heard only in the ear piece speaker

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -11,6 +11,10 @@ import java.util.Map;
 import java.util.UUID;
 
 import android.support.annotation.Nullable;
+import android.os.Build;
+import android.os.Handler;
+import android.content.Context;
+import android.media.AudioManager;
 import android.util.Base64;
 import android.util.Log;
 import android.util.SparseArray;
@@ -472,6 +476,26 @@ class PeerConnectionObserver implements PeerConnection.Observer {
     @Override
     public void onAddTrack(final RtpReceiver receiver, final MediaStream[] mediaStreams) {
         Log.d(TAG, "onAddTrack");
+
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return;
+        }
+        
+        setSpeakerOn(true);
+        final Handler mHandler = new Handler();
+        // First call not always succeeds
+        mHandler.postDelayed(() -> setSpeakerOn(true), 500);
+    }
+
+    private void setSpeakerOn(boolean on) {
+        AudioManager audioManager = (AudioManager) webRTCModule.getCurrentActivityHack().getSystemService(Context.AUDIO_SERVICE);
+
+        boolean wasOn = audioManager.isSpeakerphoneOn();
+        if (wasOn == on) {
+            return;
+        }
+        audioManager.setMode(AudioManager.MODE_IN_CALL);
+        audioManager.setSpeakerphoneOn(true);
     }
 
     @Nullable

--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -11,6 +11,13 @@ import java.util.Map;
 import java.util.UUID;
 
 import android.support.annotation.Nullable;
+import android.app.Activity;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHeadset;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Handler;
 import android.content.Context;
@@ -480,22 +487,51 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return;
         }
-        
-        setSpeakerOn(true);
-        final Handler mHandler = new Handler();
-        // First call not always succeeds
-        mHandler.postDelayed(() -> setSpeakerOn(true), 500);
+
+        setSpeakerOn(!isBluetoothHeadsetConnected());
+        startListeningHeadsetChanges();
+    }
+
+    public static boolean isBluetoothHeadsetConnected() {
+        BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        return mBluetoothAdapter != null && mBluetoothAdapter.isEnabled()
+            && mBluetoothAdapter.getProfileConnectionState(BluetoothHeadset.HEADSET) == BluetoothHeadset.STATE_CONNECTED;
+    }
+
+    public final BroadcastReceiver mReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)) {
+                setSpeakerOn(false);
+            } else if (BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)) {
+                setSpeakerOn(true);
+            }
+        }
+    };
+
+    private void startListeningHeadsetChanges() {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+        filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECT_REQUESTED);
+        filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+        getContext().registerReceiver(mReceiver, filter);
     }
 
     private void setSpeakerOn(boolean on) {
-        AudioManager audioManager = (AudioManager) webRTCModule.getCurrentActivityHack().getSystemService(Context.AUDIO_SERVICE);
+        final Activity context = getContext();
+        context.setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
 
         boolean wasOn = audioManager.isSpeakerphoneOn();
         if (wasOn == on) {
             return;
         }
-        audioManager.setMode(AudioManager.MODE_IN_CALL);
-        audioManager.setSpeakerphoneOn(true);
+        audioManager.setSpeakerphoneOn(on);
+    }
+
+    private Activity getContext() {
+        return webRTCModule.getCurrentActivityHack();
     }
 
     @Nullable

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1,5 +1,6 @@
 package com.oney.WebRTCModule;
 
+import android.app.Activity;
 import android.media.AudioAttributes;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -73,6 +74,10 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
         localStreams = new HashMap<>();
 
         ThreadUtils.runOnExecutor(() -> initAsync(options));
+    }
+
+    public Activity getCurrentActivityHack() {
+        return super.getCurrentActivity();
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "1.75.0-hive-6",
+  "version": "1.75.0-hive-7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"


### PR DESCRIPTION
**Steps to reproduce:**

1. Log in to the app 
2. Tap on any camera
3. Start live streaming

**Expected:** 

Live streaming should be played through the media speaker. 

**Actual:**

The volume is very low as it is heard only in the ear piece speaker and can be heard only if the phone is kept very close to the ears

**Note:**

This is now observed in all the phones running on Android 10 and 11. 

https://jira.bgchtest.info/browse/MA1-418