### PR TITLE
MA1-419:

### DIFF
--- a/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
+++ b/android/src/main/java/com/oney/WebRTCModule/PeerConnectionObserver.java
@@ -488,7 +488,7 @@ class PeerConnectionObserver implements PeerConnection.Observer {
             return;
         }
 
-        setSpeakerOn(!isBluetoothHeadsetConnected() && !isWiredHeadsetConnected());
+        webRTCModule.setSpeakerOn(!isBluetoothHeadsetConnected() && !isWiredHeadsetConnected());
         startListeningHeadsetChanges();
     }
 
@@ -509,9 +509,9 @@ class PeerConnectionObserver implements PeerConnection.Observer {
         public void onReceive(Context context, Intent intent) {
             final String action = intent.getAction();
             if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)) {
-                setSpeakerOn(false);
+                webRTCModule.setSpeakerOn(false);
             } else if (BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)) {
-                setSpeakerOn(true);
+                webRTCModule.setSpeakerOn(true);
             }
         }
     };
@@ -524,10 +524,10 @@ class PeerConnectionObserver implements PeerConnection.Observer {
                 int state = intent.getIntExtra("state", -1);
                 switch (state) {
                     case 0:
-                        setSpeakerOn(true);
+                        webRTCModule.setSpeakerOn(true);
                         break;
                     case 1:
-                        setSpeakerOn(false);
+                        webRTCModule.setSpeakerOn(false);
                         break;
                     default:
                         Log.d(TAG, "I have no idea what the headset state is");
@@ -545,18 +545,6 @@ class PeerConnectionObserver implements PeerConnection.Observer {
 
         IntentFilter plugFilter = new IntentFilter(Intent.ACTION_HEADSET_PLUG);
         getContext().registerReceiver(plugReceiver, plugFilter);
-    }
-
-    private void setSpeakerOn(boolean on) {
-        final Activity context = getContext();
-        context.setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
-        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-
-        boolean wasOn = audioManager.isSpeakerphoneOn();
-        if (wasOn == on) {
-            return;
-        }
-        audioManager.setSpeakerphoneOn(on);
     }
 
     private Activity getContext() {

--- a/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
+++ b/android/src/main/java/com/oney/WebRTCModule/WebRTCModule.java
@@ -1,13 +1,17 @@
 package com.oney.WebRTCModule;
 
 import android.app.Activity;
+import android.content.Context;
 import android.media.AudioAttributes;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
+
+import android.media.AudioManager;
 import android.util.Log;
 import android.util.SparseArray;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -994,5 +998,31 @@ public class WebRTCModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void useAudioOutput(int audioOutputAndroid) {
         WebRtcAudioTrack.setAudioTrackUsageAttribute(audioOutputAndroid);
+    }
+
+    void setSpeakerOn(boolean on) {
+        Activity context = getCurrentActivityHack();
+        context.setVolumeControlStream(AudioManager.STREAM_VOICE_CALL);
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+
+        boolean wasOn = audioManager.isSpeakerphoneOn();
+        if (wasOn == on) {
+            return;
+        }
+        audioManager.setSpeakerphoneOn(on);
+    }
+
+    @ReactMethod
+    public void startAudio(Promise promise) {
+        Log.d(TAG, "switch to ear speakers");
+        setSpeakerOn(false);
+        promise.resolve(Boolean.TRUE);
+    }
+
+    @ReactMethod
+    public void stopAudio(Promise promise) {
+        Log.d(TAG, "switch to loud speakers");
+        setSpeakerOn(true);
+        promise.resolve(Boolean.TRUE);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc",
-  "version": "1.75.0-hive-8",
+  "version": "1.75.0-hive-9",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/react-native-webrtc/react-native-webrtc.git"


### PR DESCRIPTION
In order to be able to re-route audio to ear-speakers instead of the loudspeaker I had to do some refactor:

- Move switching to the module
- Declare two methods accessible from JS: `startAudio` and `stopAudio`

https://jira.bgchtest.info/browse/MA1-419